### PR TITLE
Discard IPv6 ranges published by Azure, pending support for IPv6 ranges

### DIFF
--- a/script/azure_get_ip_range.sh
+++ b/script/azure_get_ip_range.sh
@@ -2,8 +2,7 @@
 
 # Azure: https://www.microsoft.com/en-us/download/details.aspx?id=56519
 
-# I get the feeling that this URL will eventually change...so I'm making
-# this a variable
+# Sneaky way to find the direct download URL for the IP address ranges
 JSON_URL="$(curl -s 'https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519' | grep 'downloadretry' | grep -oP '(?<=\")https.*?(?=\")')"
 
 ERRORS_FOUND=()
@@ -23,4 +22,13 @@ if (( ${#ERRORS_FOUND[@]} > 0 )) ; then
 	exit 1
 fi
 
-curl -s $JSON_URL | jq -r '.values | .[].properties.addressPrefixes[]'
+#
+# Filter out IPv6 ranges
+#
+# TODO: Support IPv6
+#
+only_ipv4() {
+	grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
+}
+
+curl -s $JSON_URL | jq -r '.values | .[].properties.addressPrefixes[]' | only_ipv4


### PR DESCRIPTION
@PauloMigAlmeida, this module is super!

Azure now publishes IPv6 ranges which prevents this module from building due to trying to pass an IPv6 CIDR block into a function that is explicitly designed to only work with IPv4:

https://github.com/PauloMigAlmeida/kernel-mod-cloud-packet-stats/blob/6cdbcc50f1117e0ffe2048bcd47af0d55c30aa32/script/process_cidr.py#L27

Any guidance on what needs to be done to upgrade this module to support both IPv4 and IPv6?